### PR TITLE
Add motorola blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adds motorola account blacklist
 
 ## [0.7.3] - 2020-04-14
 ### Changed

--- a/node/middlewares/parse.ts
+++ b/node/middlewares/parse.ts
@@ -2,7 +2,8 @@ import { json } from 'co-body'
 import { ENABLED_GLOBALLY } from './../constants'
 
 export async function parseAndValidate(ctx: Context, next: () => Promise<any>) {
-  if (!ENABLED_GLOBALLY) {
+  const { account } = ctx.vtex
+  if (!ENABLED_GLOBALLY || account.startsWith('motorola')) {
     ctx.body = 'Service not enabled.'
     ctx.status = 200
     return


### PR DESCRIPTION
Since motorola has some problems with the 404 page theme and `motorolaus` has a problem with its bindings we block to these accounts.