### PR TITLE
fix: remove motorola from blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed motorola account blacklist
 
 ## [0.7.7] - 2021-06-22
 ### Removed

--- a/node/middlewares/parse.ts
+++ b/node/middlewares/parse.ts
@@ -1,9 +1,8 @@
 import { json } from 'co-body'
 import { ENABLED_GLOBALLY } from './../constants'
 
-export async function parseAndValidate(ctx: Context, next: () => Promise<any>) {
-  const { account } = ctx.vtex
-  if (!ENABLED_GLOBALLY || account.startsWith('motorola')) {
+export async function parseAndValidate(ctx: Context, next: () => Promise<any>) {  
+  if (!ENABLED_GLOBALLY) {
     ctx.body = 'Service not enabled.'
     ctx.status = 200
     return


### PR DESCRIPTION
Motorola was complaining that they were not able to use availability-notify app and that's because they were not getting notifications by broadcaster