### PR TITLE
Hotfix: Remove unnecessary policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove unnecessary policy from `/notify` route
+
 ## [0.8.0] - 2022-06-02
 
 ### Added

--- a/node/service.json
+++ b/node/service.json
@@ -8,15 +8,7 @@
   "routes": {
     "notify": {
       "path": "/notify",
-      "public": false,
-      "access": "authorized",
-      "policies": [
-        {
-          "effect": "allow",
-          "actions": ["post"],
-          "principals": ["vrn:apps:*:{{account}}:*:app/vtex.broadcaster@*"]
-        }
-      ]
+      "public": false
     }
   }
 }


### PR DESCRIPTION
The [previous PR](https://github.com/vtex-apps/broadcaster/pull/44) added a policy to the `/notify` route which seems to have prevented the Catalog Broadcaster service from sending notifications to the app. This version `0.8.0` was not yet deployed and has been deprecated.

This PR removes the policy, which seems to solve the problem. After publishing a new beta version `0.8.1-beta.0` without this policy, catalog change events are being pushed successfully in account `sandboxusdev` - [see Splunk](https://vtex.splunkcloud.com/en-US/app/vtex_io_apps/search?q=search%20index%3D*%20*broadcaster*%20account%3Dsandboxusdev&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-60m%40m&latest=now&sid=1654201744.1991977_F9219AD1-CEE7-4994-9B44-A66186FF72C5).