### PR TITLE
Feature/remove motorola from blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Removed motorola from blacklist
+
 ## [0.8.1] - 2022-06-03
 
 ### Fixed

--- a/node/middlewares/parse.ts
+++ b/node/middlewares/parse.ts
@@ -3,8 +3,7 @@ import { json } from 'co-body'
 import { ENABLED_GLOBALLY } from '../constants'
 
 export async function parseAndValidate(ctx: Context, next: () => Promise<any>) {
-  const { account } = ctx.vtex
-  if (!ENABLED_GLOBALLY || account.startsWith('motorola')) {
+  if (!ENABLED_GLOBALLY) {
     ctx.body = 'Service not enabled.'
     ctx.status = 200
     return


### PR DESCRIPTION
## Description:
- Motorola is blacklisted they are currently trying to use an app called `availability-notify` which utilices this app to trigger any inventory changes.

## Changes made:
- Remove Motorola from blacklist

---
Duplicate of https://github.com/vtex-apps/broadcaster/pull/61.