### PR TITLE
[USAAPPTEAM-708] Notify subaccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- App setting `notifySubaccounts` to allow notifications to be duplicated to any related subaccounts
+
 ## [0.8.1] - 2022-06-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -22,12 +22,28 @@
     },
     {
       "name": "vbase-read-write"
+    },
+    {
+      "name": "Get_Account_By_Identifier"
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "portal.vtexcommercestable.com.br",
+        "path": "/api/*"
+      }
     }
   ],
   "settingsSchema": {
     "title": "VTEX Catalog Broadcaster",
     "type": "object",
     "properties": {
+      "notifySubaccounts": {
+        "title": "Notify Subaccounts",
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, if this app is installed in a main account, notifications will also be sent to any related subaccounts"
+      },
       "targetWorkspace": {
         "title": "Notify Target Workspace",
         "type": "string",

--- a/node/clients/broadcaster.ts
+++ b/node/clients/broadcaster.ts
@@ -11,8 +11,8 @@ export class BroadcasterClient extends AppClient {
     })
   }
 
-  public notifyWorkspace(payload: BroadcasterEvent): Promise<any> {
-    return this.http.post(`/notify`, payload, {
+  public notify(payload: BroadcasterEvent): Promise<any> {
+    return this.http.post(`/_v/self/notify`, payload, {
       headers: {
         ...this.options?.headers,
       },

--- a/node/index.ts
+++ b/node/index.ts
@@ -6,6 +6,7 @@ import { parseAndValidate } from './middlewares/parse'
 import { throttle } from './middlewares/throttle'
 import { pushNotification } from './middlewares/pushNotification'
 import { notifyTargetWorkspace } from './middlewares/notifyTargetWorkspace'
+import { notifyAllSubaccounts } from './middlewares/notifyAllSubaccounts'
 
 const TREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
@@ -27,11 +28,23 @@ const clients: ClientsConfig<Clients> = {
 export default new Service<Clients, State, ParamsContext>({
   clients,
   routes: {
+    // notifications from catalog
     notify: method({
       POST: [
         throttle,
         parseAndValidate,
         pushNotification,
+        notifyAllSubaccounts,
+        notifyTargetWorkspace,
+      ],
+    }),
+    // notifications from other vtex.broadcaster instances
+    notifySelf: method({
+      POST: [
+        throttle,
+        parseAndValidate,
+        pushNotification,
+        notifyAllSubaccounts,
         notifyTargetWorkspace,
       ],
     }),

--- a/node/middlewares/notifyAllSubaccounts.ts
+++ b/node/middlewares/notifyAllSubaccounts.ts
@@ -1,0 +1,65 @@
+import { BroadcasterClient } from '../clients/broadcaster'
+
+const TIMEOUT_MS = 3000
+const RETRIES = 2
+
+export async function notifyAllSubaccounts(
+  ctx: Context,
+  next: () => Promise<any>
+) {
+  const {
+    clients: { apps, licenseManager },
+    state: { payload },
+    vtex: { account, authToken, logger, workspace },
+  } = ctx
+
+  if (workspace !== 'master') {
+    return next()
+  }
+
+  const { notifySubaccounts = false } = await apps.getAppSettings(
+    `${process.env.VTEX_APP_ID}`
+  )
+
+  if (!notifySubaccounts) {
+    return next()
+  }
+
+  const { accountName, sites = [] } = await licenseManager
+    .getAccountData(authToken)
+    .catch((error) => {
+      logger.error({
+        message: 'getAccountData-error',
+        error,
+      })
+      return {}
+    })
+
+  // if accountName doesn't match the current account, then the app is running in a subaccount
+  if (!accountName || accountName !== account) return next()
+
+  // instance new client for each target subaccount
+  for (const subaccount of sites) {
+    // skip the main account
+    if (subaccount.name !== account) {
+      const broadcasterClient = new BroadcasterClient(
+        {
+          ...ctx.vtex,
+          account: subaccount.name,
+          workspace: 'master',
+        },
+        {
+          retries: RETRIES,
+          timeout: TIMEOUT_MS,
+        }
+      )
+      broadcasterClient.notify(payload).catch((error) => {
+        logger.warn({
+          message: 'notifySubaccount-error',
+          error,
+        })
+      })
+    }
+  }
+  next()
+}

--- a/node/middlewares/notifyTargetWorkspace.ts
+++ b/node/middlewares/notifyTargetWorkspace.ts
@@ -14,7 +14,7 @@ export async function notifyTargetWorkspace(
   } = ctx
 
   if (workspace !== 'master') {
-    return
+    return next()
   }
 
   const { targetWorkspace } = await apps.getAppSettings(
@@ -22,7 +22,7 @@ export async function notifyTargetWorkspace(
   )
 
   if (!targetWorkspace || targetWorkspace === workspace) {
-    return
+    return next()
   }
 
   // instance new client for target workspace
@@ -37,7 +37,7 @@ export async function notifyTargetWorkspace(
     }
   )
 
-  broadcasterClient.notifyWorkspace(payload).catch((error) => {
+  broadcasterClient.notify(payload).catch((error) => {
     if (error?.response?.status === 404) {
       ctx.vtex.logger.warn("Target workspace not set or doesn't exist")
     }

--- a/node/service.json
+++ b/node/service.json
@@ -9,6 +9,17 @@
     "notify": {
       "path": "/notify",
       "public": false
+    },
+    "notifySelf": {
+      "path": "/_v/self/notify",
+      "public": false,
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["post"],
+          "principals": ["vrn:apps:*:*:*:app/vtex.broadcaster@*"]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
If two or more VTEX accounts share the same catalog, we call these "subaccounts". The initial account (the first to be created) is known as the "main account". Because the accounts share a catalog, when SKUs are changed or their inventory/price are updated, broadcaster notifications for these events are only sent in the main account. 

Because the subaccounts may have VTEX IO apps running that need to receive broadcaster notifications, this PR adds a new app setting to enable catalog change notifications to be forwarded (duplicated) to each of the subaccounts related to a given main account. 

In this situation the app setting would need to be enabled in the main account. This will cause the broadcaster app to make a request to License Manager to get a list of subaccounts related to the current account. It then forwards the notification to each of them. 

This has been published as a beta version (`vtex.broadcaster@0.8.2-beta.2`) for testing. You can make a change to a SKU in account `sandboxusdev` and then use the following Splunk query to verify that the event is forwarded to subaccounts `uniteu` and `googleauth`: https://vtex.splunkcloud.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dcourier%20account%3Dgoogleauth%20OR%20account%3Duniteu%20*broadcast*&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-30m%40m&latest=now&sid=1657831313.7514912_6FCAE5D3-4C94-42BE-80A2-A5ED7724692B