### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ When the Broadcaster app sends an event, it contains a payload with the followin
 | `ProductId` | Product ID on VTEX. This field is optional and is sent only in a Marketplace context, when an affiliate generates the Catalog event. | long |
 | `An` | Account Name on VTEX, shown in the store’s VTEX Admin URL. | string |
 | `IdAffiliate` | Affiliate ID generated automatically in the configuration. This field is optional and is sent only in a Marketplace context, when an affiliate generates the Catalog event. | string |
-| `SellerChain` | Sellers involved in the chain. This field is optional and is sent only in a Marketplace context with [Multilevel Omnichenel Inventory](https://help.vtex.com/en/tutorial/multilevel-omnichannel-inventory--7M1xyCZWUyCB7PcjNtOyw4), when an affiliate generates the Catalog event. When there is more than one seller in the chain, they are all included in this field separated by a forward slash (`/`). Example: `"cea/rihappy"`. | string |
+| `SellerChain` | Sellers involved in the chain. This field is optional and is sent only in a Marketplace context with [Multilevel Omnichannel Inventory](https://help.vtex.com/en/tutorial/multilevel-omnichannel-inventory--7M1xyCZWUyCB7PcjNtOyw4), when an affiliate generates the Catalog event. When there is more than one seller in the chain, they are all included in this field separated by a forward slash (`/`). Example: `"cea/rihappy"`. | string |
 | `DateModified` | Date when the item was updated. | string |
 | `IsActive` | Identifies whether the product is active or not. If `true` the product/SKU is active. | boolean |
 | `StockModified` | Identifies that the inventory level has been changed. If `false`, the inventory level has not been changed. | boolean |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Broadcaster Adapter
+# Broadcaster
 
 The Broadcaster app is designed to adapt catalog broadcaster changes to an event in IO's Events system.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ When the Broadcaster app sends an event, it contains a payload with the followin
 | `HasStockKeepingUnitModified` | Identifies that the product/SKU details have changed, such as name, description, weight, etc. If `true`, the product/SKU details changed. | boolean |
 | `HasStockKeepingUnitRemovedFromAffiliate` | Identifies that the product is no longer associated with the trade policy. If `true`, the trade policy has changed. | boolean |
 
-## Notifications in franchise accounts
+## Notifications in subaccounts
 
 When attempting to listen for catalog change notifications in a [subaccount](https://help.vtex.com/en/tutorial/creating-subaccount-multi-store-multi-domain--tutorials_510), you will likely find that your app is not receiving notifications. This is because, by default, catalog change notifications are only sent to the Broadcaster app installed in the main account.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,9 +27,10 @@ When the Broadcaster app sends an event, it contains a payload with the followin
 | Field Name | Description | Type |
 | - | - | - |
 | `IdSku` | SKU ID on VTEX. | string |
-| `ProductId`| Product ID on VTEX. | long |
-| `An`| Account Name on VTEX, shown in the store’s VTEX Admin URL. | string |
-| `IdAffiliate` | Affiliate ID generated automatically in the configuration. | string |
+| `ProductId` | Product ID on VTEX. This field is optional and is sent only in a Marketplace context, when an affiliate generates the Catalog event. | long |
+| `An` | Account Name on VTEX, shown in the store’s VTEX Admin URL. | string |
+| `IdAffiliate` | Affiliate ID generated automatically in the configuration. This field is optional and is sent only in a Marketplace context, when an affiliate generates the Catalog event. | string |
+| `SellerChain` | Sellers involved in the chain. This field is optional and is sent only in a Marketplace context with [Multilevel Omnichenel Inventory](https://help.vtex.com/en/tutorial/multilevel-omnichannel-inventory--7M1xyCZWUyCB7PcjNtOyw4), when an affiliate generates the Catalog event. When there is more than one seller in the chain, they are all included in this field separated by a forward slash (`/`). Example: `"cea/rihappy"`. | string |
 | `DateModified` | Date when the item was updated. | string |
 | `IsActive` | Identifies whether the product is active or not. If `true` the product/SKU is active. | boolean |
 | `StockModified` | Identifies that the inventory level has been changed. If `false`, the inventory level has not been changed. | boolean |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,57 @@
 # Broadcaster Adapter
 
-The Broadcaster adapter is designed to adapt broadcaster catalog changes to an event in IO's Events system.
+The Broadcaster app is designed to adapt catalog broadcaster changes to an event in IO's Events system.
 
-With the catalog changes being broadcasted to IO, you can have apps that listen to the catalog changes and do tasks according to the changes. For example, the [Availability Notify](https://developers.vtex.com/vtex-developer-docs/docs/vtex-availability-notify) app uses the Broadcaster Adapter to monitor inventory updates. Once the requested SKU gets back in stock, the app will email shoppers who asked to be notified.
+Typically, the Broadcaster app is aimed at developing another IO app that receives the events and calls handler functions to treat the events. For more details about this scenario, see the [Receiving Catalog Changes on VTEX IO](https://developers.vtex.com/docs/guides/how-to-receive-catalog-changes-on-vtex-io) guide.
 
-![broadcaster-architecture](https://user-images.githubusercontent.com/67270558/158252905-3480125a-fabe-4db3-bb4d-7c7dea74f8ef.png)
+For example, the [Availability Notify](https://developers.vtex.com/vtex-developer-docs/docs/vtex-availability-notify) app uses the Broadcaster app to monitor inventory updates. Once the requested SKU gets back in stock, the app will email shoppers who asked to be notified.
 
-The broadcaster adapter receives a POST request with the data of the SKU that changed, and then it will push an event to the Event system to broadcast to apps that want to listen to these changes.
+```mermaid
+flowchart LR
+a1("Catalog changes\n(Catalog broadcaster)\n")
+a2("Broadcaster app")
+b1("Event system")
+b2("Changes broadcast\nto other apps\n(e.g.: Availability Notify)\n\n")
 
-> ⚠️
->
-> The Broadcaster Adapter app receives catalog changes from the same account where the app is installed and not from sellers.
+a1 -- \nSKU that\nchanged\n\n\n --> a2 --> b1 --> b2
+```
 
-## SKU Data
+The Broadcaster app receives a POST request from the catalog broadcaster with the data of the SKU that changed, and then it pushes an event to the Event system to broadcast to apps that will listen to these changes.
 
-When the Broadcaster Adapter app sends an event, it contains a payload with the following fields.
+> ⚠️ The Broadcaster app receives catalog changes from the same account where the app is installed and not from sellers.
 
-| Field Name                                | Description                                                                                                                                                  | Type    |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `IdSku`                                   | SKU ID in VTEX                                                                                                                                               | string  |
-| `ProductId`                               | Product ID in VTEX                                                                                                                                           | long    |
-| `An`                                      | Account Name in VTEX, shown in the store’s VTEX Admin url.                                                                                                   | string  |
-| `IdAffiliate`                             | Affiliate ID generated automatically in the configuration.                                                                                                   | string  |
-| `DateModified`                            | Date when the item was updated.                                                                                                                              | string  |
-| `IsActive`                                | Identifies whether the product is active or not. If `true` the product/SKU is active                                                                         | boolean |
-| `StockModified`                           | Identifies that the inventory level has been altered. If `false`, the inventory level has not been changed.                                                  | boolean |
-| `PriceModified`                           | Identifies that the price has been altered. If `false`, the product/SKU price has not been changed.                                                          | boolean |
-| `HasStockKeepingUnitModified`             | Identifies that the product/SKU registration data has changed, such as name, description, weight, etc. If `true`, the product/SKU registration data changed. | boolean |
-| `HasStockKeepingUnitRemovedFromAffiliate` | Identifies that the product is no longer associated with the trade policy. If `true`, the trade policy has changed.                                          | boolean |
+## SKU data
 
-## Regarding Franchise Accounts
+When the Broadcaster app sends an event, it contains a payload with the following fields.
 
-When attempting to listen for catalog change notifications in a **[franchise account](https://help.vtex.com/en/tutorial/what-is-a-franchise-account--kWQC6RkFSCUFGgY5gSjdl)** (sometimes referred to as a **"subaccount"**), you will likely find that notifications are not being received by your app. This is because by default, catalog change notifications are only sent to the Broadcaster Adapter in the **main account**.
+| Field Name | Description | Type |
+| - | - | - |
+| `IdSku` | SKU ID on VTEX. | string |
+| `ProductId`| Product ID on VTEX. | long |
+| `An`| Account Name on VTEX, shown in the store’s VTEX Admin URL. | string |
+| `IdAffiliate` | Affiliate ID generated automatically in the configuration. | string |
+| `DateModified` | Date when the item was updated. | string |
+| `IsActive` | Identifies whether the product is active or not. If `true` the product/SKU is active. | boolean |
+| `StockModified` | Identifies that the inventory level has been changed. If `false`, the inventory level has not been changed. | boolean |
+| `PriceModified` | Identifies that the price has been changed. If `false`, the product/SKU price has not been changed. | boolean |
+| `HasStockKeepingUnitModified` | Identifies that the product/SKU details have changed, such as name, description, weight, etc. If `true`, the product/SKU details changed. | boolean |
+| `HasStockKeepingUnitRemovedFromAffiliate` | Identifies that the product is no longer associated with the trade policy. If `true`, the trade policy has changed. | boolean |
+
+## Notifications in franchise accounts
+
+When attempting to listen for catalog change notifications in a [subaccount](https://help.vtex.com/en/tutorial/creating-subaccount-multi-store-multi-domain--tutorials_510), you will likely find that your app is not receiving notifications. This is because, by default, catalog change notifications are only sent to the Broadcaster app installed in the main account.
 
 ### "Notify Subaccounts" setting
 
-The app installed in the main account can be configured to push a notification event to all of the associated franchise accounts / subaccounts.
+The Broadcaster app installed in the main (parent) account can be configured to push a notification event to all associated subaccounts.
 
-To access this setting, search for `My Apps` in the VTEX Admin, then search the list of installed apps for `Broadcaster Adapter`. Click on `Settings`. Finally, activate the checkbox for `Notify Subaccounts` and click `Save`.
+To perform this setting, follow these steps:
+
+1. Go to **My Apps** in the VTEX Admin.
+2. In the list of installed apps, search for **Broadcaster**.
+3. Click `Settings` in the app box.
+4. Activate the checkbox to `Notify Subaccounts`.
+5. Click `Save`.
 
 ## Testing the app
 
@@ -45,20 +59,12 @@ By default, when the Broadcaster Adapter app sends events, these events are only
 
 ### "Notify Target Workspace" setting
 
-The app installed in the master workspace can be configured to push a notification event to a target workspace of your choice in addition to pushing it in the master workspace.
+The app installed in the master workspace can be configured to push a notification event to a target workspace of your choice in addition to the master workspace.
 
-To access this setting, search for `My Apps` in the VTEX Admin, then search the list of installed apps for `Broadcaster Adapter`. Click on `Settings`. Finally, input the name of the workspace you wish to notify in the `Notify Target Workspace` field and click `Save`.
+To configure this setting, follow these steps:
 
-### Event simulation via REST API
-
-You can simulate an event by making a `POST` request to `app.io.vtex.com/vtex.broadcaster/v0/{{account}}/{{workspace}}/notify`
-with the body:
-
-```
-{
-	"HasStockKeepingUnitModified": true,
-	"IdSku": {{SKU id}}
-}
-```
-
-This endpoint requires a `VtexidClientAutCookie` header for authentication.
+1. Go to **My Apps** in the VTEX Admin
+2. In the list of installed apps, search for **Broadcaster**.
+3. Click `Settings`.
+4. Enter the name of the workspace you wish to notify in the **Notify Target Workspace** field.
+5. Click `Save`.


### PR DESCRIPTION
This PR updates the README with:

- Remove "Adapter" from title
- Text and formatting improvements
- Change the diagram to mermaid format
- Reference to the [Receiving Catalog Changes on VTEX IO](https://developers.vtex.com/docs/guides/how-to-receive-catalog-changes-on-vtex-io) article
- Remove the event simulation API, since this is public documentation and it is not available for non-VTEXers
- Add the `SellerChain` field in the table
- Update the description of `ProductId` and `IdAffiliate` fields